### PR TITLE
Bump to v2.0.1.hf1 and drop unused PyYAML wheels

### DIFF
--- a/potato.bat
+++ b/potato.bat
@@ -182,7 +182,6 @@ xcopy /Y /E /Q "%FULL_SOURCE%\*" "%ADDON_INSTALL_DIR%\%ADDON_NAME%\"
 echo [INFO] Installed to: "%ADDON_INSTALL_DIR%\%ADDON_NAME%"
 echo [INFO] Branch: !GIT_BRANCH!
 echo [INFO] Restart Blender, then enable "LSPotato" in Preferences ^> Add-ons.
-echo [INFO] First enable installs the bundled wheels (PyYAML) - allow a moment.
 echo [INFO] For a fully faithful test use Blender's "Install from Disk" on the
 echo [INFO] dist zip, or run: blender --command extension validate
 goto :eof

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -16,8 +16,9 @@
 
 
 # Extension metadata now lives in blender_manifest.toml (Blender 4.2+ extension
-# format) — the legacy `bl_info` dict has been removed. Third-party deps (PyYAML)
-# ship as wheels declared in the manifest, so the old sys.path vendor shim is gone.
+# format) — the legacy `bl_info` dict has been removed. The add-on is pure Python
+# with no bundled wheels (the old PyYAML dependency and sys.path vendor shim are
+# gone).
 
 import bpy  # type: ignore
 

--- a/src/blender_manifest.toml
+++ b/src/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "LSPotato"
-version = "2.0.0"
+version = "2.0.1.hf1"
 name = "LSPotato"
 tagline = "Utility tools for the LSCherry toon-shader project"
 maintainer = "Lvoxx"
@@ -26,25 +26,15 @@ copyright = [
   "2025 Lvoxx",
 ]
 
-# PyYAML ships platform-specific wheels (optional libyaml C extension), so the
-# supported platforms are restricted to those for which a wheel is bundled.
-platforms = ["windows-x64", "macos-x64", "macos-arm64", "linux-x64"]
-
-# Bundled 3rd-party Python modules.
-# https://docs.blender.org/manual/en/dev/advanced/extensions/python_wheels.html
-wheels = [
-  "./wheels/PyYAML-6.0.2-cp313-cp313-win_amd64.whl",
-  "./wheels/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl",
-  "./wheels/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl",
-  "./wheels/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-]
+# Pure-Python add-on — no compiled/platform-specific wheels are bundled, so the
+# extension is universal (no `platforms` restriction) and ships no `wheels`.
 
 # Resources this add-on needs. Each reason is a short single sentence (<= 64
 # chars, no trailing punctuation).
 # NOTE: code using `network` should also honour `bpy.app.online_access`.
 [permissions]
-network = "Download LSRegistry asset registry and updates"
-files = "Read and write LSCherry asset and registry files"
+network = "Download LSCherry releases and add-on updates"
+files = "Read and write LSCherry asset and config files"
 
 [build]
 paths_exclude_pattern = [


### PR DESCRIPTION
- Bump manifest version 2.0.0 -> 2.0.1.hf1
- Remove `wheels` and `platforms` from manifest: PyYAML is no longer used (serializer removed) and the wheel files don't exist, which caused "Python wheel missing" / per-platform validation errors. The add-on is now a universal pure-Python extension.
- Update permission reason strings (drop removed LSRegistry references)
- Remove stale "installs bundled wheels (PyYAML)" notice from potato.bat
- Refresh the wheels comment in src/__init__.py